### PR TITLE
Rearchitect the app presentation code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "egui_extras",
  "egui_taffy",
  "embed-manifest",
+ "indexmap",
  "ipnetwork",
  "iter_tools",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "4.5", features = ["derive"] }
 eframe = { version = "0.31.1", features = ["wayland"] }
 egui_extras = { version = "0.31.1", features = ["svg"] }
 egui_taffy = "0.7.0"
+indexmap = "2.9.0"
 ipnetwork = "0.21.1"
 iter_tools = "0.29.0"
 rfd = { version = "0.15", default-features = false, features = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
 channel = "nightly-2025-06-12"
 components = ["rust-src"]
-targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
 profile = "default"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,17 @@
-use std::collections::HashMap;
 use std::ops::Not;
 
 #[cfg(target_os = "linux")]
 use ::{anyhow::ensure, clap::Parser, libc::geteuid};
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use eframe::egui::{
     Align, CentralPanel, Layout, ScrollArea, TopBottomPanel, ViewportBuilder,
     global_theme_preference_switch, vec2,
 };
 use eframe::{NativeOptions, egui};
+use indexmap::IndexMap;
+use iter_tools::Itertools;
 use rfd::AsyncFileDialog;
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 use crate::modal::{ModalDisplay, ModalLevel};
@@ -30,190 +32,307 @@ fn main() -> Result<()> {
         }
 
         if cli.daemon {
-            ensure!(unsafe { geteuid() == 0 }, "not authorized");
+            ensure!(unsafe { geteuid() == 0 }, "daemon not running as root");
 
             daemon::daemon_main(cli)?;
             return Ok(());
         }
     }
 
-    ui_main()
-}
-
-fn ui_main() -> Result<()> {
     let mut opts = NativeOptions::default();
     opts.viewport = ViewportBuilder::default()
         .with_inner_size(vec2(300., 400.))
         .with_min_inner_size(vec2(300., 200.));
+    eframe::run_native(
+        "ow2 server picker",
+        opts,
+        Box::new(|cc| Ok(Box::new(App::new(cc).unwrap()))),
+    )
+    .map_err(|e| anyhow!("{}", e.to_string()))
+}
 
-    let mut picked_file: Option<rfd::FileHandle> = None;
-    let mut file_pick_task: Option<JoinHandle<Option<rfd::FileHandle>>> = None;
+struct FileSelectionTask {
+    /// Whether to start the daemon after receiving the file.
+    start_daemon: bool,
 
-    let mut prefixes = prefixes::load();
-    prefixes.sort_by_key(|v| v.name.clone());
-    let mut server_selections = prefixes
-        .iter()
-        .map(|v| (v.key.clone(), false))
-        .collect::<HashMap<_, _>>();
-    let (update_modal, read_modal) = tokio::sync::watch::channel(Option::<ModalDisplay>::None);
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_io()
-        .build()?;
-    eframe::run_simple_native("OW2 Server Picker", opts, move |ctx, _fr| {
-        egui_extras::install_image_loaders(ctx);
-        ctx.style_mut(|style| {
+    /// An associated join handle.
+    handle: JoinHandle<Option<rfd::FileHandle>>,
+}
+
+struct App {
+    /// Application's runtime.
+    runtime: tokio::runtime::Runtime,
+
+    /// Selected regions.
+    region_states: IndexMap<prefixes::Region, bool>,
+
+    /// Game executable selected in file dialog.
+    game_exe: Option<rfd::FileHandle>,
+
+    /// A receiver for the current file selection task.
+    file_selection_task_rx: watch::Receiver<Option<FileSelectionTask>>,
+
+    /// A sender for the current file selection task.
+    file_selection_task_tx: watch::Sender<Option<FileSelectionTask>>,
+
+    /// A receiver for the current modal display.
+    modal_rx: watch::Receiver<Option<ModalDisplay>>,
+
+    /// A sender for the current modal display.
+    modal_tx: watch::Sender<Option<ModalDisplay>>,
+}
+
+impl App {
+    fn new(cc: &eframe::CreationContext<'_>) -> Result<Self> {
+        egui_extras::install_image_loaders(&cc.egui_ctx);
+
+        cc.egui_ctx.style_mut(|style| {
             style.interaction.selectable_labels = false;
         });
-        if file_pick_task.as_ref().is_some_and(|t| t.is_finished()) {
-            let task = file_pick_task.take().unwrap();
-            let file = runtime.block_on(task);
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_io()
+            .build()?;
+
+        let region_states = prefixes::load()
+            .iter()
+            .sorted_by_key(|&region| &region.name)
+            .map(|region| (region.clone(), false))
+            .collect::<IndexMap<_, _>>();
+
+        let (file_selection_task_tx, file_selection_task_rx) =
+            watch::channel(Option::<FileSelectionTask>::None);
+        let (modal_tx, modal_rx) = watch::channel(Option::<ModalDisplay>::None);
+
+        {
+            let mut fst_rx = file_selection_task_rx.clone();
+            let mut m_rx = modal_rx.clone();
+            let ctx = cc.egui_ctx.clone();
+
+            runtime.spawn(async move {
+                loop {
+                    tokio::select! {
+                        result = fst_rx.changed() => {
+                            if result.is_err() { break }
+                        },
+                        result = m_rx.changed() => {
+                            if result.is_err() { break }
+                        }
+                    }
+
+                    ctx.request_repaint();
+                }
+            });
+        }
+
+        Ok(Self {
+            runtime,
+            file_selection_task_rx,
+            file_selection_task_tx,
+            modal_rx,
+            modal_tx,
+            game_exe: None,
+            region_states,
+        })
+    }
+
+    fn run_exe_selection(&self, start_daemon: bool) {
+        let handle = self.runtime.spawn(async move {
+            let res = AsyncFileDialog::new()
+                .set_title("Find your Overwatch installation")
+                .add_filter("Overwatch.exe", &["exe"])
+                .pick_file()
+                .await;
+            res
+        });
+
+        self.file_selection_task_tx
+            .send(Some(FileSelectionTask {
+                start_daemon,
+                handle,
+            }))
+            .expect("failed to send file selection task");
+    }
+
+    fn handle_file_picker_task(&mut self) {
+        let completed = self
+            .file_selection_task_rx
+            .borrow()
+            .as_ref()
+            .is_some_and(|t| t.handle.is_finished());
+
+        if completed {
+            let task = self.file_selection_task_tx.send_replace(None).unwrap();
+            let file = self.runtime.block_on(task.handle);
             if let Err(e) = file {
-                update_modal
+                self.modal_tx
                     .send(Some(ModalDisplay {
                         level: ModalLevel::Error,
                         title: "Unable to read the file selection".to_string(),
                         content: e.to_string(),
                     }))
-                    .ok();
+                    .expect("failed to send modal");
             } else if let Some(file) = file.unwrap() {
-                picked_file = Some(file);
+                self.game_exe = Some(file);
+
+                if task.start_daemon {
+                    self.start_daemon();
+                }
             }
         }
+    }
+
+    fn start_daemon(&self) {
+        let any_selected = self.region_states.iter().any(|(_, &selected)| selected);
+
+        if !any_selected {
+            self.modal_tx
+                .send(Some(ModalDisplay {
+                    level: ModalLevel::Error,
+                    title: "No regions selected".to_string(),
+                    content: "Please select at least one region".to_string(),
+                }))
+                .expect("failed to send modal");
+
+            return;
+        }
+
+        if self.stop_daemon(true).is_err() {
+            return;
+        }
+
+        let blocked_regions = self
+            .region_states
+            .iter()
+            .filter_map(|(region, selected)| selected.not().then(|| region.key.clone()));
+
+        let game_exe = self
+            .game_exe
+            .as_ref()
+            .unwrap()
+            .path()
+            .to_string_lossy()
+            .to_string();
+
+        if let Err(e) = daemon::start(blocked_regions, game_exe) {
+            self.modal_tx
+                .send(Some(ModalDisplay {
+                    level: ModalLevel::Error,
+                    title: "Cannot enable blocking".to_string(),
+                    content: format!("Failed to activate blocking due to an error:\n\n{}", e)
+                        .to_string(),
+                }))
+                .expect("failed to send an error modal");
+        } else {
+            self.modal_tx
+                .send(Some({
+                    ModalDisplay {
+                        level: ModalLevel::Success,
+                        title: "Server list updated".to_string(),
+                        content: "Restart Overwatch to avoid connection issues.".to_string(),
+                    }
+                }))
+                .expect("failed to send a success modal");
+        }
+    }
+
+    fn stop_daemon(&self, silent: bool) -> Result<()> {
+        if let Err(e) = daemon::kill() {
+            self.modal_tx
+                .send(Some(ModalDisplay {
+                    level: ModalLevel::Error,
+                    title: "Cannot disable blocking".to_string(),
+                    content: format!("Failed to deactivate blocking due to an error:\n\n{}", e),
+                }))
+                .expect("failed to send an error modal");
+
+            return Err(e);
+        } else if !silent {
+            self.modal_tx
+                .send(Some({
+                    ModalDisplay {
+                        level: ModalLevel::Success,
+                        title: "Server blocking disabled".to_string(),
+                        content: "Restart Overwatch for the changes to apply.".to_string(),
+                    }
+                }))
+                .expect("failed to send a success modal");
+        }
+
+        Ok(())
+    }
+
+    fn on_game_path_btn_click(&self) {
+        self.run_exe_selection(false);
+    }
+
+    fn on_disable_btn_click(&self) {
+        let _ = self.stop_daemon(false);
+    }
+
+    fn on_enable_btn_click(&self) {
+        if self.game_exe.is_none() {
+            return self.run_exe_selection(true);
+        }
+
+        self.start_daemon();
+    }
+
+    fn render_bottom_bar(&self, ctx: &egui::Context) {
         TopBottomPanel::bottom("bottom panel").show(ctx, |ui| {
             ui.horizontal(|ui| {
                 global_theme_preference_switch(ui);
-                let result = ui
-                    .with_layout(Layout::right_to_left(Align::Center), |ui| -> Result<()> {
-                        let has_file = picked_file.is_some();
-                        let any_selected = server_selections.iter().any(|(_, &selected)| selected);
-                        let start_clicked = ui
-                            .add_enabled(has_file, egui::Button::new("enable").small())
-                            .clicked();
-                        if start_clicked && !any_selected {
-                            update_modal
-                                .send(Some(ModalDisplay {
-                                    level: ModalLevel::Error,
-                                    title: "No regions selected".to_string(),
-                                    content: "Please select at least one region".to_string(),
-                                }))
-                                .ok();
-                        }
-                        if start_clicked && has_file && any_selected {
-                            if let Err(e) = daemon::kill() {
-                                eprintln!("{e:#?}");
-                            }
 
-                            let blocked_servers = server_selections
-                                .iter()
-                                .filter_map(|(key, selected)| selected.not().then(|| key.clone()));
-
-                            let res = daemon::start(
-                                blocked_servers,
-                                picked_file
-                                    .clone()
-                                    .unwrap()
-                                    .path()
-                                    .to_string_lossy()
-                                    .to_string(),
-                            )
-                            .context("failed to start daemon");
-                            if let Err(e) = res {
-                                update_modal
-                                    .send(Some(ModalDisplay {
-                                        level: ModalLevel::Error,
-                                        title: "Failed to start the daemon".to_string(),
-                                        content: e.to_string(),
-                                    }))
-                                    .ok();
-                            }
-
-                            update_modal
-                                .send(Some(ModalDisplay {
-                                    level: ModalLevel::Info,
-                                    title: "Server list updated".to_string(),
-                                    content: "Please restart Overwatch to avoid connection issues."
-                                        .to_string(),
-                                }))
-                                .ok();
-                        }
-                        if ui.small_button("disable").clicked() {
-                            if let Err(e) = daemon::kill() {
-                                update_modal
-                                    .send(Some(ModalDisplay {
-                                        level: ModalLevel::Error,
-                                        title: "Failed to stop the daemon".to_string(),
-                                        content: e.to_string(),
-                                    }))
-                                    .ok();
-                            }
-                        }
-                        let mut select_path = ui.small_button("select game path");
-                        if !has_file {
-                            select_path = select_path.highlight();
-                        }
-                        if select_path.clicked() || start_clicked && picked_file.is_none() {
-                            if file_pick_task.is_none() {
-                                let ctx = ui.ctx().clone();
-                                let task = runtime.spawn(async move {
-                                    let res = AsyncFileDialog::new()
-                                        .set_title("Find your Overwatch installation")
-                                        .add_filter("Overwatch.exe", &["exe"])
-                                        .pick_file()
-                                        .await;
-                                    ctx.request_repaint();
-                                    res
-                                });
-                                file_pick_task.replace(task);
-                            }
-                        }
-
-                        Ok(())
-                    })
-                    .inner;
-
-                if let Err(e) = result {
-                    update_modal
-                        .send(Some(ModalDisplay {
-                            level: ModalLevel::Error,
-                            title: "Failed to start the daemon".to_string(),
-                            content: e.to_string(),
-                        }))
-                        .ok();
-                }
-            });
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    if ui.small_button("enable").clicked() {
+                        self.on_enable_btn_click();
+                    }
+                    if ui.small_button("disable").clicked() {
+                        self.on_disable_btn_click();
+                    }
+                    if ui.small_button("select game path").clicked() {
+                        self.on_game_path_btn_click();
+                    }
+                })
+            })
         });
+    }
+
+    fn render_central_panel(&mut self, ctx: &egui::Context) {
         CentralPanel::default().show(ctx, |ui| {
             ui.label("select desired matchmaking regions");
             ui.separator();
             ScrollArea::vertical().show(ui, |ui| {
-                for region in &prefixes {
-                    if widgets::prefix_widget(
-                        ui,
-                        &region.name,
-                        &region.code,
-                        server_selections[&region.key],
-                    )
-                    .clicked()
-                    {
-                        server_selections
-                            .entry(region.key.clone())
-                            .and_modify(|v| *v = !*v);
+                for (region, selected) in self.region_states.iter_mut() {
+                    let widget = widgets::prefix_widget(ui, &region.name, &region.code, *selected);
+
+                    if widget.clicked() {
+                        *selected = !*selected;
                     }
                 }
             });
         });
+    }
 
+    fn render_modal(&mut self, ctx: &egui::Context) {
         let mut clear_modal = false;
 
-        if let Some(msg) = &*read_modal.borrow() {
+        if let Some(msg) = &*self.modal_rx.borrow() {
             modal::show_modal(ctx, msg, || clear_modal = true);
         }
 
         if clear_modal {
-            update_modal.send(None).ok();
+            self.modal_tx.send(None).ok();
         }
-    })
-    .map_err(|e| anyhow!("{}", e.to_string()))?;
+    }
+}
 
-    Ok(())
+impl eframe::App for App {
+    fn update(&mut self, ctx: &egui::Context, _: &mut eframe::Frame) {
+        self.handle_file_picker_task();
+
+        self.render_bottom_bar(ctx);
+        self.render_central_panel(ctx);
+        self.render_modal(ctx);
+    }
 }

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -61,7 +61,7 @@ pub fn show_modal(
         });
         ui.separator();
         ui.label(RichText::new(&msg.content));
-        ui.separator();
+        ui.add_space(3.);
 
         ui.with_layout(
             egui::Layout::top_down_justified(egui::Align::Center),

--- a/src/prefixes.rs
+++ b/src/prefixes.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 use std::sync::LazyLock;
 
@@ -140,6 +141,12 @@ pub struct Region {
     pub code: String,
     pub ping: IpAddr,
     pub prefixes: Vec<IpNetwork>,
+}
+
+impl Hash for Region {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+    }
 }
 
 impl Display for Region {


### PR DESCRIPTION
> [!NOTE]
> This branch is based on #4 - after it is merged, this branch can be rebased on `main` and that commit could be dropped.

- The app is now stateful, meaning it has a struct that holds its state, and implements a number of methods - all separated by their concerns, as well as the trait for the egui app.

  This should make the code much easier to read and maintain in the long run by avoiding deeply indented code trees, and large chains of if statements that are hard to reason with.

The following changes were made during the rearchitecting:

- The message when attempting to run daemon as non-root has been changed

- File selection task now also holds whether or not the daemon must run after the file is selected.

  This fixes the confusing experience where you would click "enable", it would prompt for a file, and then do nothing, while making the user think the blocking was enabled, when it wasn't - that required an additional click.

  A previous commit with a quick attempt at fixing that by blocking the "enable" button when no file is selected was reverted as well.

- File selection task has been changed to use tokio watcher. This allows us to trigger a repaint whenever the file selection task changes.

- Changes to modal display info watcher are now tracked as well, and will also trigger a repaint. This fixes a non-critical issue where a modal could be sent but not displayed until the next repaint caused by input.

- Removed a separate sorted vector of regions by switching to an indexed hashmap for region toggle states and sorting it directly.

- Critical code paths that are expected to run now use `expect` to trigger a panic when they aren't working as intended instead of being poorly handled by the code itself.

- An additional separator before the close button in modal has been replaced with padding instead.
