### PR TITLE
Remove targets from the toolchain config

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
 channel = "nightly-2025-06-12"
 components = ["rust-src"]
-targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
 profile = "default"


### PR DESCRIPTION
Rustup seems to have trouble downloading linux target on Windows, and
having it is not a requirement for building this project on Windows.
