### PR TITLE
Add sorting option

### DIFF
--- a/assets/icons/arrow-down-0-1.svg
+++ b/assets/icons/arrow-down-0-1.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-down01-icon lucide-arrow-down-0-1"><path d="m3 16 4 4 4-4"/><path d="M7 20V4"/><rect x="15" y="4" width="4" height="6" ry="2"/><path d="M17 20v-6h-2"/><path d="M15 20h4"/></svg>

--- a/assets/icons/arrow-down-a-z.svg
+++ b/assets/icons/arrow-down-a-z.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-down-az-icon lucide-arrow-down-a-z"><path d="m3 16 4 4 4-4"/><path d="M7 20V4"/><path d="M20 8h-5"/><path d="M15 10V6.5a2.5 2.5 0 0 1 5 0V10"/><path d="M15 14h5l-5 6h5"/></svg>

--- a/assets/icons/arrow-up-1-0.svg
+++ b/assets/icons/arrow-up-1-0.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-up10-icon lucide-arrow-up-1-0"><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/><path d="M17 10V4h-2"/><path d="M15 10h4"/><rect x="15" y="14" width="4" height="6" ry="2"/></svg>

--- a/assets/icons/arrow-up-z-a.svg
+++ b/assets/icons/arrow-up-z-a.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-up-za-icon lucide-arrow-up-z-a"><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/><path d="M15 4h5l-5 6h5"/><path d="M15 20v-3.5a2.5 2.5 0 0 1 5 0V20"/><path d="M20 18h-5"/></svg>

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -18,6 +18,16 @@ pub enum PingStatus {
     Unreachable,
 }
 
+impl PingStatus {
+    pub fn as_millis_or(&self, default: u128) -> u128 {
+        if let PingStatus::Reachable(duration) = &self {
+            duration.as_millis()
+        } else {
+            default
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct PingUpdate(pub String, pub PingStatus);
 

--- a/src/regions.rs
+++ b/src/regions.rs
@@ -1,0 +1,78 @@
+use std::cmp::Ordering;
+
+use crate::{ping, prefixes};
+
+pub struct RegionEntry {
+    pub region: prefixes::Region,
+    pub ping: ping::PingStatus,
+    pub selected: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum RegionSortBy {
+    Name,
+    Ping,
+}
+
+impl std::fmt::Display for RegionSortBy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            RegionSortBy::Name => "name",
+            RegionSortBy::Ping => "ping",
+        };
+        write!(f, "{name}")
+    }
+}
+
+pub struct RegionSorting {
+    pub by: RegionSortBy,
+    pub asc: bool,
+}
+
+impl RegionSorting {
+    pub fn ordering_name(&self) -> &'static str {
+        if self.asc { "ascending" } else { "descending" }
+    }
+
+    pub fn toggle_asc(&mut self) {
+        self.asc = !self.asc
+    }
+
+    pub fn next_property(&self) -> RegionSortBy {
+        match self.by {
+            RegionSortBy::Name => RegionSortBy::Ping,
+            RegionSortBy::Ping => RegionSortBy::Name,
+        }
+    }
+
+    pub fn cycle_property(&mut self) {
+        self.by = self.next_property()
+    }
+
+    pub fn as_cmp(&self) -> impl Fn(&RegionEntry, &RegionEntry) -> Ordering {
+        let by = self.by;
+        let asc = self.asc;
+
+        move |a, b| {
+            let ord = match by {
+                RegionSortBy::Name => a.region.name.cmp(&b.region.name),
+                RegionSortBy::Ping => {
+                    let a_ping = a.ping.as_millis_or(1000);
+                    let b_ping = b.ping.as_millis_or(1000);
+                    a_ping.cmp(&b_ping)
+                }
+            };
+
+            if asc { ord } else { ord.reverse() }
+        }
+    }
+}
+
+impl Default for RegionSorting {
+    fn default() -> Self {
+        Self {
+            by: RegionSortBy::Name,
+            asc: true,
+        }
+    }
+}


### PR DESCRIPTION
Adds a small button at right top of the window to sort regions by either
their name or ping. Icon choice is what I could find in Lucide and what
made sense to me.

Sorting is implemented by sorting on the region states indexed map. This
should be relatively performant.

I've decided against implementing sorting by region code. I think it
would be better to implement a very simple search instead, though this
will require rethinking how the sorting is implemented to allow for
intermediate state (all regions -> filtered & sorted regions ->
display).

To avoid unnecessary work during the rendering, sorting is only done
when sorting method changes or when there were any ping updates and the
list is sorted by ping.
